### PR TITLE
Add optional third argument `hw_timer` to startSensors() to select and keep track of which HW timer is used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,43 +7,48 @@ ESP32 Arduino IDE library for managing OneWire DS18B20 temperature sensors.
 <br>Just set the number of desired sensors and a GPIO pin number and you are good to go.
 
 #### An simple interface for OneWire DS18B20 sensors.
-- `logger.startSensors( 3, 5 )`
+
+  - `logger.startSensors( 3, 5 )`
 <br>Starts max 3 sensors on GPIO 5 that are scanned and updated every 750ms.
-- `logger.sensorCount()`
+  - `logger.startSensors( 3, 5, 1 )`
+<br>Starts max 3 sensors on GPIO 5 that are scanned and updated every 750ms.
+<br>Use ESP32 HW timer 1. If no timer number is given, timer 0 will be used.
+  - `logger.sensorCount()`
 <br>Get the number of sensors actually connected.
-- `logger.getSensorTemp( 0 )`
+  - `logger.getSensorTemp( 0 )`
 <br>Get a temperature reading from the first sensor.
 
 #### With easy temperature logging to FFat.
-- `sensor.startTempLogging( 180 )`
+
+  - `sensor.startTempLogging( 180 )`
 <br>Starts temperature logging to FFat every 180 seconds.
-<br>The interval and log state are saved in NVS. 
-<br>If after a reboot `startSensors()` is called logging will resume with the specified interval. 
-- `sensor.stopTempLogging()`
-<br>Stops temperature logging to FFat. 
-- `sensor.isTempLogging()`
+<br>The interval and log state are saved in NVS.
+<br>If after a reboot `startSensors()` is called logging will resume with the specified interval.
+  - `sensor.stopTempLogging()`
+<br>Stops temperature logging to FFat.
+  - `sensor.isTempLogging()`
 <br>Gives the current temperature logging state.
 
-Temperature logging writes to a csv file formatted as `1970-01-01.log` if no system time is set before.
-<br>Logging is based on UTC. A typical log entry looks like:
+Temperature logging writes to a csv file formatted as `1970-01-01.log` if no system time is set before. Logging is based on UTC. A typical log entry looks like:
+
 ````bash
 1564356928,26.69,23.00,18.44
 ````
-- Where `1564356928` is `Mon Jul 29 2019 01:35:28 GMT+0200 (Central European Summer Time)`
-<br>JS `Date` is the number of milliseconds since 01-01-1970 while the UNIX time is the number of seconds since then.
-<br>So to process these time values with JavaScript just take the UNIX time value and multiply it with 1000 to get a valid JS `Date` object. 
-<br>In a console this would be: `new Date( 1564356928 * 1000 )`
-- `26.69,23.00,18.44` are the logged sensor temperatures at that time.
-- A start marker is written to the log file every time sensors are started.
+
+  - The number `1564356928` is the Unix time `Mon Jul 29 2019 01:35:28 GMT+0200` when used in JS as: `new Date( 1564356928 * 1000 )`.
+<br>Because JS `Date` is the number of milliseconds since 01-01-1970 while the UNIX time is the number of seconds since then.
+<br>So to process these time values with JavaScript just take the UNIX time value and multiply it with 1000 to get a valid JS `Date` object. (with a one second resolution ofcourse)
+  - `26.69,23.00,18.44` are the logged sensor temperatures at that time.
+  - A start marker is written to the log file every time sensors are started.
 <br>A start marker looks like `#1572769710,FFatSensor start` where the number is a UNIX timestamp.
 
 #### Wait! There's more!
 
-- `sensor.startErrorLogging()`
+  - `sensor.startErrorLogging()`
 <br>Starts sensor error logging to FFat.
-- `sensor.stopErrorLogging()`
+  - `sensor.stopErrorLogging()`
 <br>Stops sensor error logging to FFat.
-- `sensor.isErrorLogging()`
+  - `sensor.isErrorLogging()`
 <br>Gives the current error logging state.
 
 Error logging writes to `sensor_error.txt`.
@@ -53,10 +58,9 @@ FFatSensor runs fine without FFat partition mounted, but then you have no loggin
 
 #### Depends on:
 
-- ESP32 FFat library. (only needed to log to file)
-- ESP32 [OneWire](https://github.com/stickbreaker/OneWire) library by Chuck Todd.
-<br>Use this library instead of the standard Arduino version which will not work for ESP32 MCUs.
-- ESP32 [Task](https://github.com/CelliesProjects/Task) by Neil Kolban.
+  - ESP32 FFat library. (only needed to log to file)
+  - ESP32 [OneWire](https://github.com/stickbreaker/OneWire) library by Chuck Todd. Use this library instead of the standard Arduino version which will not work for ESP32 MCUs.
+  - ESP32 [Task](https://github.com/CelliesProjects/Task) by Neil Kolban.
 
 #### How to use:
 

--- a/README.md
+++ b/README.md
@@ -8,25 +8,25 @@ ESP32 Arduino IDE library for managing OneWire DS18B20 temperature sensors.
 
 #### An simple interface for OneWire DS18B20 sensors.
 
-  - `logger.startSensors( 3, 5 )`
+- `logger.startSensors( 3, 5 )`
 <br>Starts max 3 sensors on GPIO 5 that are scanned and updated every 750ms.
-  - `logger.startSensors( 3, 5, 1 )`
+- `logger.startSensors( 3, 5, 1 )`
 <br>Starts max 3 sensors on GPIO 5 that are scanned and updated every 750ms.
 <br>Use ESP32 HW timer 1. If no timer number is given, timer 0 will be used.
-  - `logger.sensorCount()`
+- `logger.sensorCount()`
 <br>Get the number of sensors actually connected.
-  - `logger.getSensorTemp( 0 )`
+- `logger.getSensorTemp( 0 )`
 <br>Get a temperature reading from the first sensor.
 
 #### With easy temperature logging to FFat.
 
-  - `sensor.startTempLogging( 180 )`
+- `sensor.startTempLogging( 180 )`
 <br>Starts temperature logging to FFat every 180 seconds.
 <br>The interval and log state are saved in NVS.
 <br>If after a reboot `startSensors()` is called logging will resume with the specified interval.
-  - `sensor.stopTempLogging()`
+- `sensor.stopTempLogging()`
 <br>Stops temperature logging to FFat.
-  - `sensor.isTempLogging()`
+- `sensor.isTempLogging()`
 <br>Gives the current temperature logging state.
 
 Temperature logging writes to a csv file formatted as `1970-01-01.log` if no system time is set before. Logging is based on UTC. A typical log entry looks like:
@@ -35,20 +35,20 @@ Temperature logging writes to a csv file formatted as `1970-01-01.log` if no sys
 1564356928,26.69,23.00,18.44
 ````
 
-  - The number `1564356928` is the Unix time `Mon Jul 29 2019 01:35:28 GMT+0200` when used in JS as: `new Date( 1564356928 * 1000 )`.
+- The number `1564356928` is the Unix time `Mon Jul 29 2019 01:35:28 GMT+0200` when used in JS as: `new Date( 1564356928 * 1000 )`.
 <br>Because JS `Date` is the number of milliseconds since 01-01-1970 while the UNIX time is the number of seconds since then.
 <br>So to process these time values with JavaScript just take the UNIX time value and multiply it with 1000 to get a valid JS `Date` object. (with a one second resolution ofcourse)
-  - `26.69,23.00,18.44` are the logged sensor temperatures at that time.
-  - A start marker is written to the log file every time sensors are started.
+- `26.69,23.00,18.44` are the logged sensor temperatures at that time.
+- A start marker is written to the log file every time sensors are started.
 <br>A start marker looks like `#1572769710,FFatSensor start` where the number is a UNIX timestamp.
 
 #### Wait! There's more!
 
-  - `sensor.startErrorLogging()`
+- `sensor.startErrorLogging()`
 <br>Starts sensor error logging to FFat.
-  - `sensor.stopErrorLogging()`
+- `sensor.stopErrorLogging()`
 <br>Stops sensor error logging to FFat.
-  - `sensor.isErrorLogging()`
+- `sensor.isErrorLogging()`
 <br>Gives the current error logging state.
 
 Error logging writes to `sensor_error.txt`.
@@ -58,9 +58,9 @@ FFatSensor runs fine without FFat partition mounted, but then you have no loggin
 
 #### Depends on:
 
-  - ESP32 FFat library. (only needed to log to file)
-  - ESP32 [OneWire](https://github.com/stickbreaker/OneWire) library by Chuck Todd. Use this library instead of the standard Arduino version which will not work for ESP32 MCUs.
-  - ESP32 [Task](https://github.com/CelliesProjects/Task) by Neil Kolban.
+- ESP32 FFat library. (only needed to log to file)
+- ESP32 [OneWire](https://github.com/stickbreaker/OneWire) library by Chuck Todd. Use this library instead of the standard Arduino version which will not work for ESP32 MCUs.
+- ESP32 [Task](https://github.com/CelliesProjects/Task) by Neil Kolban.
 
 #### How to use:
 

--- a/src/FFatSensor.cpp
+++ b/src/FFatSensor.cpp
@@ -78,7 +78,7 @@ static inline bool _saveTempLogStateToNVS( const bool state ) {
 FFatSensor::FFatSensor() {}
 FFatSensor::~FFatSensor() {}
 
-bool FFatSensor::startSensors( const uint8_t num, const uint8_t pin ) {
+bool FFatSensor::startSensors( const uint8_t num, const uint8_t pin, const uint8_t hw_timer ) {
   if ( nullptr != _wire ) {
     ESP_LOGE( TAG, "Sensors already running. Exiting." );
     return false;
@@ -102,6 +102,7 @@ bool FFatSensor::startSensors( const uint8_t num, const uint8_t pin ) {
     return false;
   }
   _maxSensors = num;
+  _hw_timer = hw_timer;
 
   ESP_LOGD( TAG, "Created %i sensor objects.", num );
   sensorPreferences.begin( NVSKEY_NAMESPACE, false );
@@ -154,7 +155,7 @@ bool FFatSensor::startTempLogging() {
 bool FFatSensor::startTempLogging( const uint32_t seconds ) {
   if ( NULL != tempLogTimer ) return false;
   sensorPreferences.putULong( NVSKEY_INTERVAL, seconds );
-  tempLogTimer = timerBegin(0, 80, true);
+  tempLogTimer = timerBegin(_hw_timer, 80, true);
   timerAttachInterrupt(tempLogTimer, &_onTimer, true);
   timerAlarmWrite(tempLogTimer, seconds * 1000000, true);
   timerAlarmEnable(tempLogTimer);

--- a/src/FFatSensor.h
+++ b/src/FFatSensor.h
@@ -31,7 +31,7 @@ public:
   FFatSensor();
   virtual ~FFatSensor();
   /*sensor routines */
-  bool                  startSensors( const uint8_t num, const uint8_t pin );
+  bool                  startSensors( const uint8_t num, const uint8_t pin, const uint8_t hw_timer=0 );
   void                  rescanSensors();
   uint8_t               sensorCount() { return _count; };
   float                 sensorTemp( const uint8_t num ) { return _state[num].tempCelsius; };
@@ -53,6 +53,7 @@ public:
   const char *          timeStamp( const timeStamp_t type , timeStampBuffer_t &tsb );
 
 private:
+  uint8_t               _hw_timer = 0;
   uint8_t               _maxSensors = 0;
   uint8_t               _count = 0;
   sensorState_t *       _state = nullptr;


### PR DESCRIPTION
This selects which of the five ESP32 hardware timers to use.